### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class InterpolationBuffer {
   appendBuffer(position, velocity, quaternion, scale) {
     const tail = this.buffer.length - 1;
 
-    //update the last entry in the buffer if this is the same frame
+    // update the last entry in the buffer if this is the same frame
     if (this.buffer.length > 0 && this.buffer[tail].time === this.time) {
       if (position) {
         this.buffer[tail].position.copy(position);
@@ -111,7 +111,7 @@ class InterpolationBuffer {
       }
     }
 
-    if (this.state == PLAYING) {
+    if (this.state === PLAYING) {
       const mark = this.time - this.bufferTime;
       //Purge this.buffer of expired frames
       while (this.buffer.length > 0 && mark > this.buffer[0].time) {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
-const BUFFERING = 0;
-const PLAYING = 1;
+const INITIALIZING = 0;
+const BUFFERING = 1;
+const PLAYING = 2;
 
 const MODE_LERP = 0;
 const MODE_HERMITE = 1;
 
 class InterpolationBuffer {
   constructor(mode = MODE_LERP, bufferTime = 0.15) {
-    this.initialized = false;
-    this.state = BUFFERING;
+    this.state = INITIALIZING;
     this.buffer = [];
     this.bufferTime = bufferTime * 1000;
     this.time = 0;
@@ -95,17 +95,18 @@ class InterpolationBuffer {
   }
 
   update(delta) {
-    if (this.state === BUFFERING) {
-      if (this.buffer.length > 0 && !this.initialized) {
+    if (this.state === INITIALIZING) {
+      if (this.buffer.length > 0) {
         this.lastBufferFrame = this.buffer.shift();
-        this.initialized = true;
-
         this.position.copy(this.lastBufferFrame.position);
         this.quaternion.copy(this.lastBufferFrame.quaternion);
         this.scale.copy(this.lastBufferFrame.scale);
+        this.state = BUFFERING;
       }
+    }
 
-      if (this.buffer.length > 0 && this.initialized && this.time > this.bufferTime) {
+    if (this.state === BUFFERING) {
+      if (this.buffer.length > 0 && this.time > this.bufferTime) {
         this.state = PLAYING;
       }
     }
@@ -150,7 +151,7 @@ class InterpolationBuffer {
       }
     }
 
-    if (this.initialized) {
+    if (this.state !== INITIALIZING) {
       this.time += delta;
     }
   }

--- a/index.js
+++ b/index.js
@@ -48,27 +48,26 @@ class InterpolationBuffer {
   }
 
   appendBuffer(position, velocity, quaternion, scale) {
-    const tail = this.buffer.length - 1;
-
+    const tail = this.buffer.length > 0 ? this.buffer[this.buffer.length - 1] : null;
     // update the last entry in the buffer if this is the same frame
-    if (this.buffer.length > 0 && this.buffer[tail].time === this.time) {
+    if (tail && tail.time === this.time) {
       if (position) {
-        this.buffer[tail].position.copy(position);
+        tail.position.copy(position);
       }
 
       if (velocity) {
-        this.buffer[tail].velocity.copy(velocity);
+        tail.velocity.copy(velocity);
       }
 
       if (quaternion) {
-        this.buffer[tail].quaternion.copy(quaternion);
+        tail.quaternion.copy(quaternion);
       }
 
       if (scale) {
-        this.buffer[tail].scale.copy(scale);
+        tail.scale.copy(scale);
       }
     } else {
-      const priorFrame = this.buffer.length > 0 ? this.buffer[tail] : this.lastBufferFrame;
+      const priorFrame = tail || this.lastBufferFrame;
       this.buffer.push({
         position: position ? position.clone() : priorFrame.position.clone(),
         velocity: velocity ? velocity.clone() : priorFrame.velocity.clone(),

--- a/index.js
+++ b/index.js
@@ -68,36 +68,12 @@ class InterpolationBuffer {
         this.buffer[tail].scale.copy(scale);
       }
     } else {
-      if (position) {
-        position = position.clone();
-      } else {
-        position = this.buffer.length > 0 ? this.buffer[tail].position.clone() : this.lastBufferFrame.position.clone();
-      }
-
-      if (velocity) {
-        velocity = velocity.clone();
-      } else {
-        velocity = this.buffer.length > 0 ? this.buffer[tail].velocity.clone() : this.lastBufferFrame.velocity.clone();
-      }
-
-      if (quaternion) {
-        quaternion = quaternion.clone();
-      } else {
-        quaternion =
-          this.buffer.length > 0 ? this.buffer[tail].quaternion.clone() : this.lastBufferFrame.quaternion.clone();
-      }
-
-      if (scale) {
-        scale = scale.clone();
-      } else {
-        scale = this.buffer.length > 0 ? this.buffer[tail].scale.clone() : this.lastBufferFrame.scale.clone();
-      }
-
+      const priorFrame = this.buffer.length > 0 ? this.buffer[tail] : this.lastBufferFrame;
       this.buffer.push({
-        position: position,
-        velocity: velocity,
-        quaternion: quaternion,
-        scale: scale,
+        position: position ? position.clone() : priorFrame.position.clone(),
+        velocity: velocity ? velocity.clone() : priorFrame.velocity.clone(),
+        quaternion: quaternion ? quaternion.clone() : priorFrame.quaternion.clone(),
+        scale: scale ? scale.clone() : priorFrame.scale.clone(),
         time: this.time
       });
     }


### PR DESCRIPTION
Should be no functionality changes, but I didn't test it :-)

I didn't worry very much about correctness -- I figure if we ever get the sender clock sent over the network, that's the time to think about revisiting this and trying to do a better job, if ever.

Like we figured in person, we can probably get some easy efficiency wins by changing the `set` interface to do everything at once and by doing less defensive copies, but it's probably not a super big deal with order of 10 people in a room. (FYI, you could also optimize the lerping part -- calling `lerpVectors` each time does duplicate work if you're going to repeatedly call it with the same origin and target and different `alpha`.) Once we deploy this we should check the profiler to see whether it warrants improving.