### PR TITLE
update for newer Threejs version ( fixes THREE.Quaternion: Static .sl…

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class InterpolationBuffer {
   }
 
   slerp(target, r1, r2, alpha) {
-    target.slerpQuaternions(r1,r2,alpha);
+    target.slerpQuaternions(r1, r2, alpha);
   }
 
   updateOriginFrameToBufferTail() {

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class InterpolationBuffer {
   }
 
   slerp(target, r1, r2, alpha) {
-    THREE.Quaternion.slerp(r1, r2, target, alpha);
+    target.slerpQuaternions(r1,r2,alpha);
   }
 
   updateOriginFrameToBufferTail() {


### PR DESCRIPTION
…erp() has been deprecated. Use is now qm.slerpQuaternions( qa, qb, t ) instead.)