### PR TITLE
Replace deprecated Quaternion.slerp() with Quaternion.slerpQuaternions()

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ class InterpolationBuffer {
   }
 
   slerp(target, r1, r2, alpha) {
-    THREE.Quaternion.slerp(r1, r2, target, alpha);
+    target.slerpQuaternions(r1, r2, alpha);
   }
 
   updateOriginFrameToBufferTail() {


### PR DESCRIPTION
This PR replaces deprecated static THREE.Quaternion.slerp() with THREE.Quaternion.slerpQuaternions() for newer Three.js API.