### PR TITLE
TS and BJS update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# buffered-interpolation
+# buffered-interpolation-babylon
 
-This package aims to provide a solution for interpolation of position, rotation, and scale for networked THREE.js objects. 
+This is a port of Mozilla's [buffered-interpolation](https://github.com/InfiniteLee/buffered-interpolation) to BabylonJS
+
+This package aims to provide a solution for interpolation of position, rotation, and scale for networked BabylonJS objects.
 
 It specifically aims to work well both in situations with continuous and sparse network updates. 
 
@@ -13,16 +15,27 @@ For rotation (quaternions), uses spherical interpolation.
 ## Usage
 
 ```
-var InterpolationBuffer = require('buffered-interpolation');
-let interpolationBuffer = new InterpolationBuffer();
+import {
+  InterpolationBuffer,
+  BufferState,
+  BufferMode
+} from "buffered-interpolation-babylon";
+
+const buffer = new InterpolationBuffer(BufferMode.MODE_LERP, 0.1);
 ```
 
 on receipt of networked data:
 ```
-interpolationBuffer.setPosition(new THREE.Vector3(data.x, data.y, data.z));
+buffer.appendBuffer(position, velocity, orientation, scale)
 ```
 
-in some update/tick method: 
+in an onBeforeRender observable:
 ```
-object3d.position.copy(interpolationBuffer.getPosition());
+buffer.update(scene.deltaTime)
+if (buffer.state === BufferState.PLAYING) {
+  mesh.setEnabled(true);
+  mesh.position.copyFrom(buffer.position);
+  mesh.rotationQuaternion.copyFrom(buffer.quaternion);
+  mesh.scaling.copyFrom(buffer.scale);
+}
 ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,42 @@
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+export declare enum BufferState {
+    INITIALIZING = 0,
+    BUFFERING = 1,
+    PLAYING = 2
+}
+export declare enum BufferMode {
+    MODE_LERP = 0,
+    MODE_HERMITE = 1
+}
+export interface frame {
+    position: Vector3;
+    velocity: Vector3;
+    scale: Vector3;
+    quaternion: Quaternion;
+    time: number;
+}
+export declare class InterpolationBuffer {
+    state: BufferState;
+    mode: BufferMode;
+    buffer: frame[];
+    originFrame: frame;
+    position: Vector3;
+    scale: Vector3;
+    quaternion: Quaternion;
+    time: number;
+    bufferTime: number;
+    constructor(mode?: BufferMode, bufferTime?: number);
+    hermite(target: Vector3, t: number, p1: Vector3, p2: Vector3, v1: Vector3, v2: Vector3): void;
+    lerp(target: Vector3, v1: Vector3, v2: Vector3, alpha: number): void;
+    slerp(target: Quaternion, r1: Quaternion, r2: Quaternion, alpha: number): void;
+    updateOriginFrameToBufferTail(): void;
+    appendBuffer(position?: Vector3, velocity?: Vector3, quaternion?: Quaternion, scale?: Vector3): void;
+    setTarget(position: Vector3, velocity: Vector3, quaternion: Quaternion, scale: Vector3): void;
+    setPosition(position: Vector3, velocity: Vector3): void;
+    setQuaternion(quaternion: Quaternion): void;
+    setScale(scale: Vector3): void;
+    update(delta: number): void;
+    getPosition(): Vector3;
+    getQuaternion(): Quaternion;
+    getScale(): Vector3;
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,159 @@
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+export var BufferState;
+(function (BufferState) {
+    BufferState[BufferState["INITIALIZING"] = 0] = "INITIALIZING";
+    BufferState[BufferState["BUFFERING"] = 1] = "BUFFERING";
+    BufferState[BufferState["PLAYING"] = 2] = "PLAYING";
+})(BufferState || (BufferState = {}));
+export var BufferMode;
+(function (BufferMode) {
+    BufferMode[BufferMode["MODE_LERP"] = 0] = "MODE_LERP";
+    BufferMode[BufferMode["MODE_HERMITE"] = 1] = "MODE_HERMITE";
+})(BufferMode || (BufferMode = {}));
+// const vectorPool: Vector3[] = [];
+// const quatPool: Quaternion[] = [];
+const framePool = [];
+// const getPooledVector: () => Vector3 = () => vectorPool.shift() || new Vector3();
+// const getPooledQuaternion: () => Quaternion = () => quatPool.shift() || new Quaternion();
+const getPooledFrame = () => {
+    let frame = framePool.pop();
+    if (!frame) {
+        frame = { position: new Vector3(), velocity: new Vector3(), scale: new Vector3(1, 1, 1), quaternion: new Quaternion(), time: 0 };
+    }
+    return frame;
+};
+const freeFrame = f => framePool.push(f);
+export class InterpolationBuffer {
+    constructor(mode = BufferMode.MODE_LERP, bufferTime = 0.15) {
+        this.state = BufferState.INITIALIZING;
+        this.buffer = [];
+        this.bufferTime = bufferTime * 1000;
+        this.time = 0;
+        this.mode = mode;
+        this.originFrame = getPooledFrame();
+        this.position = new Vector3();
+        this.quaternion = new Quaternion();
+        this.scale = new Vector3(1, 1, 1);
+    }
+    hermite(target, t, p1, p2, v1, v2) {
+        const t2 = t * t;
+        const t3 = t * t * t;
+        const a = 2 * t3 - 3 * t2 + 1;
+        const b = -2 * t3 + 3 * t2;
+        const c = t3 - 2 * t2 + t;
+        const d = t3 - t2;
+        target.copyFrom(p1.scaleInPlace(a));
+        target.add(p2.scaleInPlace(b));
+        target.add(v1.scaleInPlace(c));
+        target.add(v2.scaleInPlace(d));
+    }
+    lerp(target, v1, v2, alpha) {
+        Vector3.LerpToRef(v1, v2, alpha, target);
+    }
+    slerp(target, r1, r2, alpha) {
+        Quaternion.SlerpToRef(r1, r2, alpha, target);
+    }
+    updateOriginFrameToBufferTail() {
+        freeFrame(this.originFrame);
+        this.originFrame = this.buffer.shift() || getPooledFrame();
+    }
+    appendBuffer(position, velocity, quaternion, scale) {
+        const tail = this.buffer.length > 0 ? this.buffer[this.buffer.length - 1] : null;
+        // update the last entry in the buffer if this is the same frame
+        if (tail && tail.time === this.time) {
+            if (position) {
+                tail.position.copyFrom(position);
+            }
+            if (velocity) {
+                tail.velocity.copyFrom(velocity);
+            }
+            if (quaternion) {
+                tail.quaternion.copyFrom(quaternion);
+            }
+            if (scale) {
+                tail.scale.copyFrom(scale);
+            }
+        }
+        else {
+            const priorFrame = tail || this.originFrame;
+            const newFrame = getPooledFrame();
+            newFrame.position.copyFrom(position || priorFrame.position);
+            newFrame.velocity.copyFrom(velocity || priorFrame.velocity);
+            newFrame.quaternion.copyFrom(quaternion || priorFrame.quaternion);
+            newFrame.scale.copyFrom(scale || priorFrame.scale);
+            newFrame.time = this.time;
+            this.buffer.push(newFrame);
+        }
+    }
+    setTarget(position, velocity, quaternion, scale) {
+        this.appendBuffer(position, velocity, quaternion, scale);
+    }
+    setPosition(position, velocity) {
+        this.appendBuffer(position, velocity, undefined, undefined);
+    }
+    setQuaternion(quaternion) {
+        this.appendBuffer(undefined, undefined, quaternion, undefined);
+    }
+    setScale(scale) {
+        this.appendBuffer(undefined, undefined, undefined, scale);
+    }
+    update(delta) {
+        if (this.state === BufferState.INITIALIZING) {
+            if (this.buffer.length > 0) {
+                this.updateOriginFrameToBufferTail();
+                this.position.copyFrom(this.originFrame.position);
+                this.quaternion.copyFrom(this.originFrame.quaternion);
+                this.scale.copyFrom(this.originFrame.scale);
+                this.state = BufferState.BUFFERING;
+            }
+        }
+        if (this.state === BufferState.BUFFERING) {
+            if (this.buffer.length > 0 && this.time > this.bufferTime) {
+                this.state = BufferState.PLAYING;
+            }
+        }
+        if (this.state === BufferState.PLAYING) {
+            const mark = this.time - this.bufferTime;
+            //Purge this.buffer of expired frames
+            while (this.buffer.length > 0 && mark > this.buffer[0].time) {
+                //if this is the last frame in the buffer, just update the time and reuse it
+                if (this.buffer.length > 1) {
+                    this.updateOriginFrameToBufferTail();
+                }
+                else {
+                    this.originFrame.position.copyFrom(this.buffer[0].position);
+                    this.originFrame.velocity.copyFrom(this.buffer[0].velocity);
+                    this.originFrame.quaternion.copyFrom(this.buffer[0].quaternion);
+                    this.originFrame.scale.copyFrom(this.buffer[0].scale);
+                    this.originFrame.time = this.buffer[0].time;
+                    this.buffer[0].time = this.time + delta;
+                }
+            }
+            if (this.buffer.length > 0 && this.buffer[0].time > 0) {
+                const targetFrame = this.buffer[0];
+                const delta_time = targetFrame.time - this.originFrame.time;
+                const alpha = (mark - this.originFrame.time) / delta_time;
+                if (this.mode === BufferMode.MODE_LERP) {
+                    this.lerp(this.position, this.originFrame.position, targetFrame.position, alpha);
+                }
+                else if (this.mode === BufferMode.MODE_HERMITE) {
+                    this.hermite(this.position, alpha, this.originFrame.position, targetFrame.position, this.originFrame.velocity.scaleInPlace(delta_time), targetFrame.velocity.scaleInPlace(delta_time));
+                }
+                this.slerp(this.quaternion, this.originFrame.quaternion, targetFrame.quaternion, alpha);
+                this.lerp(this.scale, this.originFrame.scale, targetFrame.scale, alpha);
+            }
+        }
+        if (this.state !== BufferState.INITIALIZING) {
+            this.time += delta;
+        }
+    }
+    getPosition() {
+        return this.position;
+    }
+    getQuaternion() {
+        return this.quaternion;
+    }
+    getScale() {
+        return this.scale;
+    }
+}

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,213 @@
+import { Vector3, Quaternion } from "@babylonjs/core/Maths/math.vector";
+
+export enum BufferState {
+  INITIALIZING = 0,
+  BUFFERING = 1,
+  PLAYING = 2
+}
+
+export enum BufferMode {
+  MODE_LERP = 0,
+  MODE_HERMITE = 1
+}
+
+export interface frame {
+  position: Vector3;
+  velocity: Vector3;
+  scale: Vector3;
+  quaternion: Quaternion;
+  time: number;
+}
+
+// const vectorPool: Vector3[] = [];
+// const quatPool: Quaternion[] = [];
+const framePool: frame[] = [];
+
+// const getPooledVector: () => Vector3 = () => vectorPool.shift() || new Vector3();
+// const getPooledQuaternion: () => Quaternion = () => quatPool.shift() || new Quaternion();
+
+const getPooledFrame: () => frame = () => {
+  let frame = framePool.pop();
+
+  if (!frame) {
+    frame = { position: new Vector3(), velocity: new Vector3(), scale: new Vector3(1, 1, 1), quaternion: new Quaternion(), time: 0 };
+  }
+
+  return frame;
+};
+
+const freeFrame: (f: frame) => void = f => framePool.push(f);
+
+export class InterpolationBuffer {
+  state: BufferState;
+  mode: BufferMode;
+  buffer: frame[];
+  originFrame: frame;
+  position: Vector3;
+  scale: Vector3;
+  quaternion: Quaternion;
+  time: number;
+  bufferTime: number;
+
+  constructor(mode = BufferMode.MODE_LERP, bufferTime = 0.15) {
+    this.state = BufferState.INITIALIZING;
+    this.buffer = [];
+    this.bufferTime = bufferTime * 1000;
+    this.time = 0;
+    this.mode = mode;
+
+    this.originFrame = getPooledFrame();
+    this.position = new Vector3();
+    this.quaternion = new Quaternion();
+    this.scale = new Vector3(1, 1, 1);
+  }
+
+  hermite(target: Vector3, t: number, p1: Vector3, p2: Vector3, v1: Vector3, v2: Vector3) {
+    const t2 = t * t;
+    const t3 = t * t * t;
+    const a = 2 * t3 - 3 * t2 + 1;
+    const b = -2 * t3 + 3 * t2;
+    const c = t3 - 2 * t2 + t;
+    const d = t3 - t2;
+
+    target.copyFrom(p1.scaleInPlace(a));
+    target.add(p2.scaleInPlace(b));
+    target.add(v1.scaleInPlace(c));
+    target.add(v2.scaleInPlace(d));
+  }
+
+  lerp(target: Vector3, v1: Vector3, v2: Vector3, alpha: number) {
+    Vector3.LerpToRef(v1, v2, alpha, target);
+  }
+
+  slerp(target: Quaternion, r1: Quaternion, r2: Quaternion, alpha: number) {
+    Quaternion.SlerpToRef(r1, r2, alpha, target);
+  }
+
+  updateOriginFrameToBufferTail() {
+    freeFrame(this.originFrame);
+    this.originFrame = this.buffer.shift() || getPooledFrame();
+  }
+
+  appendBuffer(position?: Vector3, velocity?: Vector3, quaternion?: Quaternion, scale?: Vector3) {
+    const tail = this.buffer.length > 0 ? this.buffer[this.buffer.length - 1] : null;
+    // update the last entry in the buffer if this is the same frame
+    if (tail && tail.time === this.time) {
+      if (position) {
+        tail.position.copyFrom(position);
+      }
+
+      if (velocity) {
+        tail.velocity.copyFrom(velocity);
+      }
+
+      if (quaternion) {
+        tail.quaternion.copyFrom(quaternion);
+      }
+
+      if (scale) {
+        tail.scale.copyFrom(scale);
+      }
+    } else {
+      const priorFrame = tail || this.originFrame;
+      const newFrame = getPooledFrame();
+      newFrame.position.copyFrom(position || priorFrame.position);
+      newFrame.velocity.copyFrom(velocity ||  priorFrame.velocity);
+      newFrame.quaternion.copyFrom(quaternion || priorFrame.quaternion);
+      newFrame.scale.copyFrom(scale || priorFrame.scale);
+      newFrame.time = this.time;
+
+      this.buffer.push(newFrame);
+    }
+  }
+
+  setTarget(position: Vector3, velocity: Vector3, quaternion: Quaternion, scale: Vector3) {
+    this.appendBuffer(position, velocity, quaternion, scale);
+  }
+
+  setPosition(position: Vector3, velocity: Vector3) {
+    this.appendBuffer(position, velocity, undefined, undefined);
+  }
+
+  setQuaternion(quaternion: Quaternion) {
+    this.appendBuffer(undefined, undefined, quaternion, undefined);
+  }
+
+  setScale(scale: Vector3) {
+    this.appendBuffer(undefined, undefined, undefined, scale);
+  }
+
+  update(delta: number) {
+    if (this.state === BufferState.INITIALIZING) {
+      if (this.buffer.length > 0) {
+        this.updateOriginFrameToBufferTail();
+        this.position.copyFrom(this.originFrame.position);
+        this.quaternion.copyFrom(this.originFrame.quaternion);
+        this.scale.copyFrom(this.originFrame.scale);
+        this.state = BufferState.BUFFERING;
+      }
+    }
+
+    if (this.state === BufferState.BUFFERING) {
+      if (this.buffer.length > 0 && this.time > this.bufferTime) {
+        this.state = BufferState.PLAYING;
+      }
+    }
+
+    if (this.state === BufferState.PLAYING) {
+      const mark = this.time - this.bufferTime;
+      //Purge this.buffer of expired frames
+      while (this.buffer.length > 0 && mark > this.buffer[0].time) {
+        //if this is the last frame in the buffer, just update the time and reuse it
+        if (this.buffer.length > 1) {
+          this.updateOriginFrameToBufferTail();
+        } else {
+          this.originFrame.position.copyFrom(this.buffer[0].position);
+          this.originFrame.velocity.copyFrom(this.buffer[0].velocity);
+          this.originFrame.quaternion.copyFrom(this.buffer[0].quaternion);
+          this.originFrame.scale.copyFrom(this.buffer[0].scale);
+          this.originFrame.time = this.buffer[0].time;
+          this.buffer[0].time = this.time + delta;
+        }
+      }
+      if (this.buffer.length > 0 && this.buffer[0].time > 0) {
+        const targetFrame = this.buffer[0];
+        const delta_time = targetFrame.time - this.originFrame.time;
+        const alpha = (mark - this.originFrame.time) / delta_time;
+
+        if (this.mode === BufferMode.MODE_LERP) {
+          this.lerp(this.position, this.originFrame.position, targetFrame.position, alpha);
+        } else if (this.mode === BufferMode.MODE_HERMITE) {
+          this.hermite(
+            this.position,
+            alpha,
+            this.originFrame.position,
+            targetFrame.position,
+            this.originFrame.velocity.scaleInPlace(delta_time),
+            targetFrame.velocity.scaleInPlace(delta_time)
+          );
+        }
+
+        this.slerp(this.quaternion, this.originFrame.quaternion, targetFrame.quaternion, alpha);
+
+        this.lerp(this.scale, this.originFrame.scale, targetFrame.scale, alpha);
+      }
+    }
+
+    if (this.state !== BufferState.INITIALIZING) {
+      this.time += delta;
+    }
+  }
+
+  getPosition() {
+    return this.position;
+  }
+
+  getQuaternion() {
+    return this.quaternion;
+  }
+
+  getScale() {
+    return this.scale;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,32 +1,35 @@
 {
-  "name": "buffered-interpolation",
-  "version": "0.2.5",
-  "description": "A class for handling interpolation of networked THREE.js objects.",
-  "homepage": "https://github.com/infinitelee/buffered-interpolation",
-  "main": "dist/buffered-interpolation.js",
-  "author": "Kevin Lee <kevin@infinite-lee.com>",
+  "name": "buffered-interpolation-babylon",
+  "version": "8.0.0",
+  "description": "A class for handling interpolation of networked Babylon JS objects.",
+  "homepage": "https://github.com/frame-xr/buffered-interpolation",
+  "main": "dist/index.js",
+  "authors": "Will Murphy <william.murphy@virbela.com> && Eric Eisaman <eric@framevr.io> && Andrew Butt Sr. <pryme8@gmail.com>",
   "license": "MPL-2.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "bugs": {
-    "url": "https://github.com/infinitelee/buffered-interpolation/issues"
+    "url": "https://github.com/frame-xr/buffered-interpolation/issues"
   },
   "scripts": {
-    "dist": "babel index.js -o dist/buffered-interpolation.js --presets=env && babel index.js -o dist/buffered-interpolation.min.js --presets=minify"
+    "dist": "tsc --outDir dist",
+    "distold": "babel index.js -o dist/buffered-interpolation.js --presets=env && babel index.js -o dist/buffered-interpolation.min.js --presets=minify"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-minify": "^0.4.3"
+    "typescript": "^5.7.2"
   },
-  "repository": "infinitelee/buffered-interpolation",
+  "peerDependencies": {
+    "@babylonjs/core": ">=8.0.0"
+  },
+  "repository": "virbela/buffered-interpolation",
   "keywords": [
     "interpolation",
     "lerping",
     "hermite",
-    "aframe",
     "multiplayer",
     "networked",
     "networking",
-    "three",
-    "three.js"
+    "babylonjs"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,102 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Enable incremental compilation */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es6",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ES2015","ES2016", "ES2017", "ES2020"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+    // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+
+    /* Modules */
+    "module": "es2020",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files */
+    // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+    // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+    // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  },
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## buffered-interpolation-babylon — BabylonJS Port

Port of Mozilla's [buffered-interpolation](https://github.com/InfiniteLee/buffered-interpolation) from THREE.js to BabylonJS, with a full rewrite to TypeScript.

### Changes

#### TypeScript Rewrite
- Replaced `index.js` (vanilla JS, global `THREE` dependency) with `index.ts` (fully typed TypeScript)
- Added `tsconfig.json` targeting ES6 with ES module output and declaration generation
- Replaced Babel build pipeline (`babel-cli`, `babel-preset-env`, `babel-preset-minify`) with `tsc`
- Build script now runs `tsc --outDir dist` instead of Babel transforms

#### THREE.js → BabylonJS
- Replaced all `THREE.Vector3` / `THREE.Quaternion` usage with `@babylonjs/core/Maths/math.vector` imports (`Vector3`, `Quaternion`)
- Adapted vector/quaternion API calls:
  - `.copy()` → `.copyFrom()`
  - `.multiplyScalar()` → `.scaleInPlace()`
  - `.lerpVectors()` → `Vector3.LerpToRef()`
  - `.slerpQuaternions()` → `Quaternion.SlerpToRef()`
- `@babylonjs/core` added as a `peerDependency` (`>=8.0.0`)

#### Exports & API
- State constants (`INITIALIZING`, `BUFFERING`, `PLAYING`) replaced with `BufferState` enum
- Mode constants (`MODE_LERP`, `MODE_HERMITE`) replaced with `BufferMode` enum
- Added `frame` interface defining the shape of interpolation frames
- `InterpolationBuffer` class and enums are named exports instead of `module.exports`
- Removed unused vector/quaternion pool helpers; kept frame pool

#### Package Metadata
- Renamed package to `buffered-interpolation-babylon`
- Bumped version to `8.0.0` to align with BabylonJS 8
- Updated authors, homepage, repository, and bug tracker URLs
- Updated keywords: removed `aframe`, `three`, `three.js`; added `babylonjs`
- Added `publishConfig` for npm registry

#### Documentation
- README updated to reflect BabylonJS usage with ES module import examples
- Usage examples show `appendBuffer()` / `buffer.update(scene.deltaTime)` pattern with `BufferState` checks